### PR TITLE
Fix Floating Sanctuary to Floating Cemetery

### DIFF
--- a/worlds/clair_obscur/data/locations.json
+++ b/worlds/clair_obscur/data/locations.json
@@ -4721,7 +4721,7 @@
     },
     {
         "internal_name": "Chest_Generic_5xLuminaPoint",
-        "name": "World Map: Dive - Below Floating Sanctuary",
+        "name": "World Map: Dive - Below Floating Cemetery",
         "location": "World Map",
         "original_item": "Consumable_LuminaPoint",
         "condition": {},

--- a/worlds/clair_obscur/data/regions.json
+++ b/worlds/clair_obscur/data/regions.json
@@ -961,7 +961,7 @@
             "World Map: Dive - N of Sirene",
             "World Map: Dive - Near SE Manor Door",
             "World Map: Dive - Below Endless Tower",
-            "World Map: Dive - Below Floating Sanctuary",
+            "World Map: Dive - Below Floating Cemetery",
             "World Map: Dive - S of Sinister Cave",
             "World Map: Dive - Near The Crows"
         ]


### PR DESCRIPTION
Floating Sanctuary => Floating Cemetery

TIL Cemetery does not have an 'a' in it. Honestly ruined my entire day