### PR TITLE
Fixed location ID mismatch

### DIFF
--- a/worlds/clair_obscur/Locations.py
+++ b/worlds/clair_obscur/Locations.py
@@ -24,7 +24,6 @@ class ClairObscurLocation(Location):
 
 
 def create_locations(world: "ClairObscurWorld", regions: Dict[str, Region]) -> None:
-    code = 0
 
     excluded_types = []
     if not world.options.gestral_shuffle:
@@ -41,10 +40,11 @@ def create_locations(world: "ClairObscurWorld", regions: Dict[str, Region]) -> N
             if location_data.type in excluded_types:
                 continue
 
+            loc_id = world.location_name_to_id[location_data.name]
             location = ClairObscurLocation(
                 world.player,
                 location_data.name,
-                offset_location_value(code),
+                loc_id,
                 region,
                 location_data.default_item
             )
@@ -60,7 +60,6 @@ def create_locations(world: "ClairObscurWorld", regions: Dict[str, Region]) -> N
                 add_rule(location, lambda state, pl=world.player, pic=pictos: state.has_group("Picto", pl, pic))
 
             region.locations.append(location)
-            code += 1
 
 
 def offset_location_value(location_id: int) -> int:
@@ -81,7 +80,7 @@ def create_location_name_to_ap_id() -> Dict[str, int]:
     Creates a map from item name to their AP item id
     """
     name_to_ap_id = {}
-    index = 1
+    index = 0
     for location in data.locations.values():
         name_to_ap_id[location.name] = offset_location_value(index)
         index += 1

--- a/worlds/clair_obscur/Rules.py
+++ b/worlds/clair_obscur/Rules.py
@@ -58,6 +58,8 @@ def set_rules(world):
         #2 gestrals in First Continent North
         add_rule(mw.get_location("Lost Gestral reward 1", player),
                  lambda state: state.can_reach_region("WM: First Continent North", player))
+        add_rule(mw.get_location("Lost Gestral reward 1", player),
+                 lambda state: state.can_reach_region("WM: First Continent North", player))
         add_rule(mw.get_location("Lost Gestral reward 2", player),
                  lambda state: state.can_reach_region("WM: First Continent North", player))
 
@@ -82,3 +84,8 @@ def set_rules(world):
                  lambda state: state.can_reach_region("WM: Sky", player))
         add_rule(mw.get_location("Lost Gestral reward 9", player),
                  lambda state: state.can_reach_region("WM: Sky", player))
+
+    #Character specific access rules- can't be added to conditions due to shuffle char option
+    if world.options.char_shuffle:
+        add_rule(mw.get_location("Sacred River: Golgra", player),
+                 lambda state: state.has("Monoco", player))

--- a/worlds/clair_obscur/data/locations.json
+++ b/worlds/clair_obscur/data/locations.json
@@ -5905,8 +5905,7 @@
         "location": "Sacred River",
         "original_item": "",
         "condition": {
-            "Painted Power": 1,
-            "Monoco": 1
+            "Painted Power": 1
         },
         "type": "Boss",
         "boss_type": "Normal"


### PR DESCRIPTION
Location creation now uses location_name_to_id to make sure location IDs are matched with the datapackage.